### PR TITLE
Add a fix to load placeholder image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -45,13 +45,12 @@ class Item extends React.Component {
       this.props.currentUser &&
       this.props.currentUser.username === this.props.item.seller.username;
 
-    let imageUrl = '/placeholder.png'
+    let imageUrl = "/placeholder.png";
     const itemImage = this.props.item.image;
 
-    if(itemImage && itemImage !== '') {
+    if (itemImage && itemImage !== "") {
       imageUrl = itemImage;
     }
-
     return (
       <div className="container page">
         <div className="text-dark">

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -44,13 +44,21 @@ class Item extends React.Component {
     const canModify =
       this.props.currentUser &&
       this.props.currentUser.username === this.props.item.seller.username;
+
+    let imageUrl = '/placeholder.png'
+    const itemImage = this.props.item.image;
+
+    if(itemImage && itemImage !== '') {
+      imageUrl = itemImage;
+    }
+
     return (
       <div className="container page">
         <div className="text-dark">
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={imageUrl}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -20,6 +20,13 @@ const mapDispatchToProps = (dispatch) => ({
 const ItemPreview = (props) => {
   const item = props.item;
 
+  let imageUrl = "/placeholder.png";
+  let itemImageUrl = item.image;
+
+  if (itemImageUrl && itemImageUrl !== "") {
+    imageUrl = itemImageUrl;
+  }
+
   const handleClick = (ev) => {
     ev.preventDefault();
     if (item.favorited) {
@@ -36,7 +43,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={imageUrl}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

When a new product is added without an image, show a placeholder image instead of a broken one.

![image](https://user-images.githubusercontent.com/35548179/187084687-9109867f-1609-499b-828d-eb7890ea7b5b.png)


- https://github.com/ObelusFamily/Anythink-Market-fi8ol/issues/2